### PR TITLE
feat(lib): make notifications show the user's avatar first

### DIFF
--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -104,7 +104,7 @@ const connect = async (userData: UserData) => {
                   : `New message from ${message.author.display_name ?? message.author.username}`,
                 {
                   body: message.content,
-                  icon: '/das_ding.png',
+                  icon: `${userData.instanceInfo.effis_url}/avatars/${message.author.avatar}` ?? '/das_ding.png',
                   renotify: true,
                   tag: 'NewMessage'
                 }


### PR DESCRIPTION
## Description
This makes notifications show the message author's avatar first before falling back to `/das_ding.png`.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->


## This is a **Logic Change**
- [x] Changes have been tested.


<!--
## This is a **UI Change**
- [ ] This has been previewed and looks as intended
-->
