### PR TITLE
fix: limit user bar width on less wide screens

### DIFF
--- a/src/routes/(logged_in)/+page.svelte
+++ b/src/routes/(logged_in)/+page.svelte
@@ -317,7 +317,7 @@
 
     #users {
       position: absolute;
-      width: 80%;
+      width: min(80%, 300px);
       right: 0;
       height: calc(100% - 60px);
       box-sizing: border-box;


### PR DESCRIPTION


## Description

limit user bar width on less wide screens

## This is a **UI Change**
- [x] This has been previewed and looks as intended

