### PR TITLE
feat: implement emoji autocompletion

### DIFF
--- a/src/lib/emoji.ts
+++ b/src/lib/emoji.ts
@@ -1908,8 +1908,7 @@ export const emojiDictionary: { [emoji: string]: string } = {
     halal: 'https://cdn.discordapp.com/emojis/1098216622621200464.webp?quality=lossless',
     haram: 'https://cdn.discordapp.com/emojis/1098216666745282670.webp?quality=lossless',
     woof: 'https://media.tenor.com/ljcdej9JsBsAAAAd/vanitas-vanitas-no-carte.gif',
-    uwoogh:
-      'https://cdn.discordapp.com/attachments/980412957794136087/1157332050056060928/suzUOOOOHHHHHHHH.png',
+    uwoogh: 'https://cdn.eludris.gay/4266150985739',
     kaldance: 'https://media.discordapp.net/stickers/1143840253476614144.png',
     flushedd: 'https://cdn.discordapp.com/emojis/1012407508901580821.webp?quality=lossless',
     pog: 'https://cdn.discordapp.com/emojis/989499974775631873.webp?quality=lossless',

--- a/src/lib/emoji.ts
+++ b/src/lib/emoji.ts
@@ -32,7 +32,7 @@ export const toUrl = (emojiName: string): string => {
   }
 
   return `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/${toCodePoints(emoji)}.svg`;
-}
+};
 
 export const emojiDictionary: { [emoji: string]: string } = {
   100: '💯',
@@ -1930,6 +1930,6 @@ export const emojiDictionary: { [emoji: string]: string } = {
     uwuki: 'https://cdn.discordapp.com/emojis/1038675327204991076.webp?quality=lossless',
     cunny: 'https://cdn.discordapp.com/emojis/1103360465641422858.webp?quality=lossless',
     ferrisballSweat: 'https://cdn.discordapp.com/emojis/1022173242695372933.webp?quality=lossless',
-    mlynar_gaming: 'https://cdn.discordapp.com/emojis/1182806139449131010.webp?quality=lossless',
+    mlynar_gaming: 'https://cdn.discordapp.com/emojis/1182806139449131010.webp?quality=lossless'
   }
 };

--- a/src/lib/emoji.ts
+++ b/src/lib/emoji.ts
@@ -20,6 +20,20 @@ export const toCodePoints = (emoji: string) => {
   return codePoint.join('-');
 };
 
+export const toUrl = (emojiName: string): string => {
+  let emoji = emojiDictionary[emojiName];
+
+  if (emoji.startsWith('http')) {
+    return emoji;
+  }
+
+  if (emoji.indexOf('\u200d') < 0) {
+    emoji = emoji.replace(/\uFE0F/g, '');
+  }
+
+  return `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/${toCodePoints(emoji)}.svg`;
+}
+
 export const emojiDictionary: { [emoji: string]: string } = {
   100: '💯',
   1234: '🔢',

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -11,7 +11,7 @@ import { visit } from 'unist-util-visit';
 import data from '$lib/user_data';
 import state from './ws';
 import { get } from 'svelte/store';
-import { emojiDictionary, toCodePoints } from './emoji';
+import { emojiDictionary, toUrl } from './emoji';
 
 let effisHost: string | undefined = undefined;
 let effisUrl: string | undefined = undefined;
@@ -204,18 +204,11 @@ export default async (content: string): Promise<string> => {
         big = '';
       }
       return res.replace(/(?<!\\):([a-zA-Z0-9_-]+):/gm, (m, emojiName, offset) => {
-        let emoji = emojiDictionary[emojiName];
-        if (emoji && res.substring(0, offset).split(/<\\?code>/gm).length % 2 == 1) {
-          if (emoji.startsWith('http')) {
-            return `<img src="${emoji}" class="emoji${big}" />`;
-          } else {
-            if (emoji.indexOf('\u200d') < 0) {
-              emoji = emoji.replace(/\uFE0F/g, '');
-            }
-            return `<img class="emoji${big}" draggable="false" alt="${emoji}" src="https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/${toCodePoints(
-              emoji
-            )}.svg" title="${emoji}"/>`;
-          }
+        let emoji = emojiDictionary[emojiName]
+        if (
+          emoji && res.substring(0, offset).split(/<\\?code>/gm).length % 2 == 1
+        ) {
+          return `<img class="emoji${big}" draggable="false" alt="${emoji}" src="${toUrl(emojiName)}" title="${emoji}"/>`;
         }
         return m;
       });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -204,11 +204,10 @@ export default async (content: string): Promise<string> => {
         big = '';
       }
       return res.replace(/(?<!\\):([a-zA-Z0-9_-]+):/gm, (m, emojiName, offset) => {
-        let emoji = emojiDictionary[emojiName]
-        if (
-          emoji && res.substring(0, offset).split(/<\\?code>/gm).length % 2 == 1
-        ) {
-          return `<img class="emoji${big}" draggable="false" alt="${emoji}" src="${toUrl(emojiName)}" title="${emoji}"/>`;
+        let emoji = emojiDictionary[emojiName];
+        if (emoji && res.substring(0, offset).split(/<\\?code>/gm).length % 2 == 1) {
+          return `<img class="emoji${big}" draggable="false" alt="${emoji}"
+            src="${toUrl(emojiName)}" title="${emoji}"/>`;
         }
         return m;
       });

--- a/src/routes/(logged_in)/MessageInput.svelte
+++ b/src/routes/(logged_in)/MessageInput.svelte
@@ -223,7 +223,7 @@
 
     let emojiPart = value.slice(0, cursorPos).replace(/(?<=\:)[a-zA-Z0-9_-]{2,}$/, `${emojiName}:`);
     let remainder = value.slice(cursorPos);
-    if (remainder && !/^\s+$/.test(remainder)) {
+    if (remainder && !/^\s+/.test(remainder)) {
       value = emojiPart + ' ' + remainder;
     } else {
       value = emojiPart + remainder;

--- a/src/routes/(logged_in)/MessageInput.svelte
+++ b/src/routes/(logged_in)/MessageInput.svelte
@@ -28,8 +28,8 @@
         if (emojiRegex.test(emojiName)) {
           if (!display.startsWith('http')) {
             console.log(emojiName, emojiName.startsWith('http'));
-            if (emojiName.indexOf('\u200d') < 0) {
-              emojiName = emojiName.replace(/\uFE0F/g, '');
+            if (display.indexOf('\u200d') < 0) {
+              display = display.replace(/\uFE0F/g, '');
             }
             display = `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/${toCodePoints(
               display

--- a/src/routes/(logged_in)/MessageInput.svelte
+++ b/src/routes/(logged_in)/MessageInput.svelte
@@ -230,6 +230,7 @@
     }
 
     currentEmoji = undefined;
+    suggestedEmoji.length = 0;
     emojiMatch = '';
     await tick();
     input.selectionStart = input.selectionEnd = emojiPart.length;

--- a/src/routes/(logged_in)/MessageInput.svelte
+++ b/src/routes/(logged_in)/MessageInput.svelte
@@ -178,8 +178,8 @@
     }
   };
 
-  const autocompleteEmoji = (emoji_name: string) => {
-    value += emoji_name.replace(emojiMatch, '') + ':';
+  const autocompleteEmoji = (emojiName: string) => {
+    value = value.slice(0, -emojiMatch.length) + emojiName + ":";
     input?.focus();
   };
 </script>

--- a/src/routes/(logged_in)/MessageInput.svelte
+++ b/src/routes/(logged_in)/MessageInput.svelte
@@ -3,7 +3,7 @@
   import Markdown from '$lib/components/Markdown.svelte';
   import userData from '$lib/user_data';
   import { request } from '$lib/request';
-  import { emojiDictionary, toCodePoints } from '$lib/emoji';
+  import { emojiDictionary, toUrl } from '$lib/emoji';
 
   export let value = '';
   export let input: HTMLTextAreaElement;
@@ -24,18 +24,9 @@
       emojiMatch = matches[1];
       let emojiRegex = new RegExp(`^${emojiMatch}`, 'i');
 
-      for (let [emojiName, display] of Object.entries(emojiDictionary)) {
+      for (let emojiName of Object.keys(emojiDictionary)) {
         if (emojiRegex.test(emojiName)) {
-          if (!display.startsWith('http')) {
-            console.log(emojiName, emojiName.startsWith('http'));
-            if (display.indexOf('\u200d') < 0) {
-              display = display.replace(/\uFE0F/g, '');
-            }
-            display = `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/${toCodePoints(
-              display
-            )}.svg`;
-          }
-          suggestedEmoji.push({ name: emojiName, display: display });
+          suggestedEmoji.push({ name: emojiName, display: toUrl(emojiName) });
         }
 
         if (suggestedEmoji.length >= maxEmoji) break;

--- a/src/routes/(logged_in)/MessageInput.svelte
+++ b/src/routes/(logged_in)/MessageInput.svelte
@@ -236,6 +236,13 @@
     input.selectionStart = input.selectionEnd = emojiPart.length;
     input?.focus();
   };
+
+  const previewEntryHover = (i: number) => {
+    currentEmoji?.classList.remove("highlight");
+    currentEmoji = emojiPreview.children[i] as HTMLButtonElement;
+    currentEmoji.classList.add("highlight");
+    currentEmojiIndex = i;
+  }
 </script>
 
 <svelte:window on:keydown={onWindowKeyDown} />
@@ -288,6 +295,7 @@
           id="emoji-preview-entry"
           type="button"
           on:click={() => autocompleteEmoji(emoji.name)}
+          on:mouseenter={() => previewEntryHover(i)}
         >
           <img id="emoji-preview-display" src={emoji.display} alt={emoji.name} />
           <div id="emoji-preview-name">{emoji.name}</div>

--- a/src/routes/(logged_in)/MessageInput.svelte
+++ b/src/routes/(logged_in)/MessageInput.svelte
@@ -12,34 +12,36 @@
   let mobile = false;
   let previewMessage = false;
 
-  let emojiMatch: string = ""
-  let suggestedEmoji: {name: string, display: string}[] = new Array;
+  let emojiMatch: string = '';
+  let suggestedEmoji: { name: string; display: string }[] = new Array();
   const maxEmoji = 10;
-  
+
   $: {
-    let matches = value.match(/:(\w{2,})$/)
+    let matches = value.match(/:(\w{2,})$/);
     suggestedEmoji.length = 0;
 
     if (matches) {
       emojiMatch = matches[1];
-      let emojiRegex = new RegExp(`^${emojiMatch}`, "i");
+      let emojiRegex = new RegExp(`^${emojiMatch}`, 'i');
 
       for (let [emojiName, display] of Object.entries(emojiDictionary)) {
         if (emojiRegex.test(emojiName)) {
           if (!display.startsWith('http')) {
-            console.log(emojiName, emojiName.startsWith("http"))
+            console.log(emojiName, emojiName.startsWith('http'));
             if (emojiName.indexOf('\u200d') < 0) {
               emojiName = emojiName.replace(/\uFE0F/g, '');
             }
-            display = `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/${toCodePoints(display)}.svg`;
+            display = `https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/${toCodePoints(
+              display
+            )}.svg`;
           }
-          suggestedEmoji.push({name: emojiName, display: display})
+          suggestedEmoji.push({ name: emojiName, display: display });
         }
 
         if (suggestedEmoji.length >= maxEmoji) break;
       }
-      console.log(emojiRegex, suggestedEmoji)
-    } 
+      console.log(emojiRegex, suggestedEmoji);
+    }
   }
 
   const onSubmit = async () => {
@@ -167,7 +169,7 @@
       await tick();
       input?.focus();
     }
-    if ((e.key == "Tab") && suggestedEmoji.length >= 0) {
+    if (e.key == 'Tab' && suggestedEmoji.length >= 0) {
       e.preventDefault();
       autocompleteEmoji(suggestedEmoji[0].name);
     }
@@ -186,10 +188,9 @@
   };
 
   const autocompleteEmoji = (emoji_name: string) => {
-    value += emoji_name.replace(emojiMatch, "") + ":";
+    value += emoji_name.replace(emojiMatch, '') + ':';
     input?.focus();
-  }
-
+  };
 </script>
 
 <svelte:window on:keydown={onWindowKeyDown} />
@@ -235,18 +236,21 @@
   </button>
   {#if suggestedEmoji.length > 0}
     <div id="emoji-preview">
-        {#each suggestedEmoji as emoji}
-        <button id="emoji-preview-entry" type="button" on:click={() => autocompleteEmoji(emoji.name)}>
-          <img id="emoji-preview-display" src={emoji.display} alt={emoji.name}>
+      {#each suggestedEmoji as emoji}
+        <button
+          id="emoji-preview-entry"
+          type="button"
+          on:click={() => autocompleteEmoji(emoji.name)}
+        >
+          <img id="emoji-preview-display" src={emoji.display} alt={emoji.name} />
           <div id="emoji-preview-name">{emoji.name}</div>
           <div id="emoji-preview-spacer" />
-          <div id="emoji-preview-sphere"></div>
+          <div id="emoji-preview-sphere" />
         </button>
       {/each}
     </div>
   {/if}
 </form>
-
 
 <style>
   .input-button {
@@ -342,7 +346,8 @@
     border: none;
   }
 
-  #emoji-preview-entry:hover, #emoji-preview-entry:focus {
+  #emoji-preview-entry:hover,
+  #emoji-preview-entry:focus {
     background-color: var(--purple-400);
     border-radius: 5px;
   }


### PR DESCRIPTION
## Description

This PR introduces an emoji previewer/autocompleter that is activated when at least the first three characters of any emoji are entered into the chat bar, including the leading colon. For example:

![image](https://github.com/eludris/client/assets/55550164/3f94f85f-58ec-44b0-9aef-e7acdc934748)

This window can be navigated using the up/down arrow keys, and a selection can be made with tab/enter or a mouse click.

If the emoji is autocompleted mid-sentence, a space is automatically added if the character after the emoji is *not* already whitespace, otherwise the existing whitespace is maintained as-is.

## This is a **Logic Change**
- [x] Changes have been tested.

## This is a **UI Change**
- [x] This has been previewed and looks as intended
