### PR TITLE
feat: make categories toggle channel visibility

### DIFF
--- a/src/lib/components/SphereBar.svelte
+++ b/src/lib/components/SphereBar.svelte
@@ -3,6 +3,7 @@
   import state from '$lib/ws';
   import userData from '$lib/user_data';
   import type { Sphere } from '$lib/types/sphere';
+  import type { Category } from '$lib/types/category';
   import { page } from '$app/stores';
   import { SphereChannelType } from '$lib/types/channel';
 
@@ -29,6 +30,11 @@
     if (window.screen.width > 1000) return { duration: 0 };
     return slide(node, params);
   };
+
+  const toggleCategory = (e: MouseEvent, c: Category) => {
+    console.log(c)
+    $state.categories[c.id].collapsed = !c.collapsed;
+  }
 </script>
 
 <div id="sphere-bar" style:width={currentSphere ? '300px' : 'auto'}>
@@ -61,16 +67,30 @@
       <hr />
       <ul id="sphere-channel-list">
         {#each currentSphere.categories as category (category.id)}
-          {#if category.id != currentSphere.id}
-            <h4 class="category">
-              > {category.name}
-            </h4>
-          {/if}
-          {#each category.channels as channel (channel.id)}
-            <a href="/channels/{channel.id}" class="channel">
-              # {channel.name}
-            </a>
-          {/each}
+          <div class="category">
+            {#if category.id != currentSphere.id}
+              <span tabindex=0 role="button" on:click={(e) => toggleCategory(e, category)}>
+                <h4 class="category-name">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="24" height="24" viewBox="4 4 16 16">
+                    {#if !category.collapsed}
+                      <path d="M12 15l-4.243-4.243 1.415-1.414L12 12.172l2.828-2.829 1.415 1.414z"/>
+                    {:else}
+                      <path d="M12.172 12L9.343 9.172l1.414-1.415L15 12l-4.243 4.243-1.414-1.415z"/>
+                    {/if}
+                  </svg>
+                  {category.name}
+                </h4>
+              </span>
+              {/if}
+              {#if !category.collapsed}
+                {#each category.channels as channel (channel.id)}
+                  <a href="/channels/{channel.id}" class="channel">
+                    # {channel.name}
+                  </a>
+                  <br/>
+                {/each}
+              {/if}
+            </div>
         {/each}
       </ul>
     </div>
@@ -135,11 +155,37 @@
 
   .category {
     margin: 10px 0;
+    user-select: none;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .category h4 {
+    margin: 0;
+  }
+  
+  .category-name {
+    color: var(--color-text);
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 5px;
+    border-radius: 5px;
+  }
+
+  .category-name:hover {
+    background-color: var(--purple-300);
   }
 
   .channel {
-    padding-left: 5px;
+    padding: 5px;
+    border-radius: 5px;
     text-decoration: none;
+  }
+  
+  .channel:hover {
+    color: var(--gray-600);
+    background-color: var(--purple-300);
   }
 
   #sphere-banner {

--- a/src/lib/components/SphereBar.svelte
+++ b/src/lib/components/SphereBar.svelte
@@ -5,13 +5,14 @@
   import type { Sphere } from '$lib/types/sphere';
   import type { Category } from '$lib/types/category';
   import { page } from '$app/stores';
-  import { SphereChannelType } from '$lib/types/channel';
+  import { SphereChannelType, type Channel } from '$lib/types/channel';
 
   let currentSphere: Sphere | null = null;
+  let currentChannel: Channel | null = null;
 
   let spheres: Sphere[] = Object.values($state.spheres ?? []);
   $: {
-    let currentChannel = $state.channels[Number.parseInt($page.params.channel_id)];
+    currentChannel = $state.channels[Number.parseInt($page.params.channel_id)];
     if (
       currentChannel &&
       (currentChannel.type == SphereChannelType.TEXT ||
@@ -84,7 +85,7 @@
               {/if}
               {#if !category.collapsed}
                 {#each category.channels as channel (channel.id)}
-                  <a href="/channels/{channel.id}" class="channel">
+                  <a href="/channels/{channel.id}" class={`channel${channel == currentChannel ? " current" : ""}`}>
                     # {channel.name}
                   </a>
                   <br/>
@@ -179,6 +180,7 @@
 
   .channel {
     padding: 5px;
+    margin: 2px;
     border-radius: 5px;
     text-decoration: none;
   }
@@ -186,6 +188,11 @@
   .channel:hover {
     color: var(--gray-600);
     background-color: var(--purple-300);
+  }
+
+  .channel.current {
+    color: var(--gray-600);
+    background-color: var(--purple-400);
   }
 
   #sphere-banner {

--- a/src/lib/types/category.ts
+++ b/src/lib/types/category.ts
@@ -1,8 +1,9 @@
-import { SphereChannel } from "./channel";
+import type { SphereChannel } from "./channel";
 
 export interface Category {
     id: number;
     name: string;
     channels: SphereChannel[];
     position: number;
+    collapsed: boolean;
 }

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -76,10 +76,8 @@ const connect = async (userData: UserData) => {
             u.members.forEach((m) => {
               state.users[m.user.id] = m.user;
             });
-            // u.channels.forEach((c) => {
-            //   state.channels[c.id] = c;
-            // });
             u.categories.forEach((c) => {
+              c.collapsed = false;  // TODO: Maybe remember this between sessions?
               state.categories[c.id] = c;
               c.channels.forEach((c) => {
                 state.channels[c.id] = c;


### PR DESCRIPTION
## Description

This PR makes it so that clicking a category toggles visibility for its child channels. As some minor feature creep, I also made ot display the active channel.

<!-- Link any issues if applicable.
Use keywords from https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

<!-- Uncomment based on the type of your changes below -->

<!--
## This is a **Logic Change**
- [x] Changes have been tested.
-->

<!--
## This is a **UI Change**
- [x] This has been previewed and looks as intended
-->
